### PR TITLE
Convert update requests to buttons

### DIFF
--- a/custom_components/pycupra/__init__.py
+++ b/custom_components/pycupra/__init__.py
@@ -46,6 +46,7 @@ from pycupra.exceptions import (
 
 from .const import (
     PLATFORMS,
+    BUTTON_INSTRUMENTS,
     CONF_BRAND,
     CONF_MUTABLE,
     #CONF_SCANDINAVIAN_MILES,
@@ -275,7 +276,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if instrument.component in PLATFORMS and is_enabled(instrument.slug_attr)
     ):
         data.instruments.add(instrument)
-        components.add(PLATFORMS[instrument.component])
+        if instrument.component == "switch" and instrument.attr in BUTTON_INSTRUMENTS:
+            components.add("button")
+        else:
+            components.add(PLATFORMS[instrument.component])
 
     hass.data[DOMAIN][entry.entry_id] = {
         UPDATE_CALLBACK: update_callback,

--- a/custom_components/pycupra/button.py
+++ b/custom_components/pycupra/button.py
@@ -1,0 +1,78 @@
+"""Support for PyCupra buttons."""
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.const import CONF_RESOURCES
+
+from . import DATA, DATA_KEY, DOMAIN, PyCupraEntity, UPDATE_CALLBACK
+from .const import BUTTON_INSTRUMENTS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up PyCupra buttons from discovery."""
+    if discovery_info is None:
+        return
+
+    async_add_entities([PyCupraButton(hass.data[DATA_KEY], *discovery_info)])
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Set up PyCupra buttons from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id][DATA]
+    coordinator = data.coordinator
+
+    if coordinator.data is not None:
+        if CONF_RESOURCES in entry.options:
+            resources = entry.options[CONF_RESOURCES]
+        else:
+            resources = entry.data[CONF_RESOURCES]
+
+        new_devices = []
+        for instrument in data.instruments:
+            if (
+                instrument.component == "switch"
+                and instrument.attr in BUTTON_INSTRUMENTS
+                and instrument.attr in resources
+            ):
+                _LOGGER.debug(
+                    "Instrument %s added to button platform", instrument.attr
+                )
+                new_devices.append(
+                    PyCupraButton(
+                        data,
+                        instrument.vehicle_name,
+                        instrument.component,
+                        instrument.attr,
+                        hass.data[DOMAIN][entry.entry_id][UPDATE_CALLBACK],
+                    )
+                )
+
+        if new_devices:
+            async_add_devices(new_devices)
+
+    return True
+
+
+class PyCupraButton(PyCupraEntity, ButtonEntity):
+    """Representation of a PyCupra button."""
+
+    @property
+    def available(self) -> bool:
+        """Return availability of the button."""
+        return self.instrument is not None
+
+    async def async_press(self) -> None:
+        """Handle button press."""
+        instrument = self.instrument
+
+        if instrument is None:
+            _LOGGER.debug("Button %s has no instrument", self.name)
+            return
+
+        _LOGGER.debug("Pressing button %s", instrument.attr)
+        await instrument.turn_on()
+        self.async_write_ha_state()
+

--- a/custom_components/pycupra/const.py
+++ b/custom_components/pycupra/const.py
@@ -50,4 +50,7 @@ PLATFORMS = {
     "device_tracker": "device_tracker",
     "switch": "switch",
     "climate": "climate",
+    "button": "button",
 }
+
+BUTTON_INSTRUMENTS = {"refresh_data", "update_data"}

--- a/custom_components/pycupra/switch.py
+++ b/custom_components/pycupra/switch.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import config_validation as cv, entity_platform, serv
 from homeassistant.const import CONF_RESOURCES
 
 from . import DATA, DATA_KEY, DOMAIN, PyCupraEntity, UPDATE_CALLBACK
+from .const import BUTTON_INSTRUMENTS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +34,8 @@ async def async_setup_entry(hass, entry, async_add_devices):
         newDevices=[]
         for instrument in data.instruments:
             if instrument.component == "switch" and instrument.attr in resources:
+                if instrument.attr in BUTTON_INSTRUMENTS:
+                    continue
                 #_LOGGER.debug(f"In switch.py.async_setup_entry. Instrument: {instrument.attr}")
                 if instrument.attr in ('departure1','departure2','departure3','departure_profile1','departure_profile2','departure_profile3', 'request_flash', 'request_honkandflash'):
                     _LOGGER.debug(f"Instrument {instrument.attr} added without callback")


### PR DESCRIPTION
This change converts the update request switches to buttons, providing a more intuitive and user-friendly interface. Buttons are more appropriate for one-time actions like requesting updates or waking up the vehicle, as they don't maintain a persistent state. This makes it easier for users to interact with these features and better aligns with Home Assistant's UI patterns for action-based controls.