### PR TITLE
Issue #49 - provide hass context to pycupra Connection

### DIFF
--- a/custom_components/pycupra/__init__.py
+++ b/custom_components/pycupra/__init__.py
@@ -1162,7 +1162,8 @@ class PyCupraCoordinator(DataUpdateCoordinator):
             password=self.entry.data[CONF_PASSWORD],
             fulldebug=self.entry.options.get(CONF_DEBUG, self.entry.data.get(CONF_DEBUG, DEFAULT_DEBUG)),
             nightlyUpdateReduction=self.entry.options.get(CONF_NIGHTLY_UPDATE_REDUCTION, self.entry.data.get(CONF_NIGHTLY_UPDATE_REDUCTION, False)),
-            logPrefix=self._logPrefix
+            logPrefix=self._logPrefix,
+            hass=self.hass
         )
         self.firebaseWanted=self.entry.options.get(CONF_FIREBASE, self.entry.data.get(CONF_FIREBASE, False))
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval)

--- a/custom_components/pycupra/config_flow.py
+++ b/custom_components/pycupra/config_flow.py
@@ -90,6 +90,7 @@ class PyCupraConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 password=self._data[CONF_PASSWORD],
                 fulldebug=False,
                 nightlyUpdateReduction= False,
+                hass=self.hass,
             )
 
             return await self.async_step_login()
@@ -293,6 +294,7 @@ class PyCupraConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 fulldebug=self.entry.options.get(CONF_DEBUG, self.entry.data.get(CONF_DEBUG, DEFAULT_DEBUG)),
                 nightlyUpdateReduction=self.entry.options.get(CONF_NIGHTLY_UPDATE_REDUCTION, self.entry.data.get(CONF_NIGHTLY_UPDATE_REDUCTION, False)),
                 logPrefix=logPrefix,
+                hass=self.hass,
             )
 
             # noinspection PyBroadException
@@ -397,6 +399,7 @@ class PyCupraConnectConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             fulldebug=False,
             nightlyUpdateReduction=False,
             logPrefix=None,
+            hass=self.hass,
         )
         try:
             #await self._connection.doLogin(tokenFile=TOKEN_FILE_NAME_AND_PATH)


### PR DESCRIPTION
pycupra did not get the hass context from homassistant-pycupra. creating `pycupra_data` directory only worked "by accident" if homeassistant process was using a writable directory as working dir.