### PR TITLE
fix: align pycupra version in
  requirements.txt with manifest.json

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pycupra>=0.2.12
+pycupra>=0.2.23


### PR DESCRIPTION
requirements.txt specified pycupra>=0.2.12 but manifest.json already requires pycupra>=0.2.23. This aligns both files
  to avoid inconsistencies when installing from requirements.txt directly.